### PR TITLE
Update $LogName to match workbook query as it was failing.

### DIFF
--- a/Scripts/Invoke-CustomAppReliability.ps1
+++ b/Scripts/Invoke-CustomAppReliability.ps1
@@ -136,7 +136,7 @@ $ComputerName = Get-ComputerInfo | Select-Object -ExpandProperty CsName
 #region APPRELIABILITY
 
 # Set Name of Log
-$LogName = "ApplicationReliability"
+$LogName = "AppReliability"
 
 $ReliabilityPayload = @()
 $ReliabilityEvents = Get-CimInstance win32_ReliabilityRecords | Where-Object { $_.EventIdentifier -match "1000|1002" -and $_.TimeGenerated -ge (Get-Date).AddHours(-24) }


### PR DESCRIPTION
Updated $LogName to 'AppReliability' to match the query built into the workbook and the Azure function version of this script.